### PR TITLE
Optionals, nullables, and iterables, oh my!

### DIFF
--- a/dist/convert-idl.js
+++ b/dist/convert-idl.js
@@ -27,7 +27,7 @@ var floatTypes = ['float', 'unrestricted float', 'double', 'unrestricted double'
 var sameTypes = ['any', 'boolean', 'Date', 'Function', 'Promise', 'void'];
 var baseTypeConversionMap = new Map(__spreadArray(__spreadArray(__spreadArray(__spreadArray(__spreadArray(__spreadArray([], __spreadArray([], bufferSourceTypes).map(function (type) { return [type, type]; })), __spreadArray([], integerTypes).map(function (type) { return [type, 'number']; })), __spreadArray([], floatTypes).map(function (type) { return [type, 'number']; })), __spreadArray([], stringTypes).map(function (type) { return [type, 'string']; })), __spreadArray([], sameTypes).map(function (type) { return [type, type]; })), [
     ['object', 'any'],
-    ['sequence', 'Array'],
+    ['sequence', 'Iterable'],
     ['record', 'Record'],
     ['FrozenArray', 'ReadonlyArray'],
     ['EventHandler', 'EventHandler'],

--- a/dist/convert-idl.js
+++ b/dist/convert-idl.js
@@ -195,7 +195,11 @@ function convertArgument(idl) {
 }
 function makeFinalType(type, idl) {
     if (idl.nullable) {
-        return ts.factory.createUnionTypeNode([type, ts.factory.createNull()]);
+        var types = [type, ts.factory.createTypeReferenceNode('null')];
+        if (idl.type !== 'return-type') {
+            types.push(ts.factory.createTypeReferenceNode('undefined'));
+        }
+        return ts.factory.createUnionTypeNode(types);
     }
     return type;
 }

--- a/src/convert-idl.ts
+++ b/src/convert-idl.ts
@@ -165,7 +165,10 @@ function createIterableMethods(name: string, keyType: ts.TypeNode, valueType: ts
   ]
 }
 
-function convertInterface(idl: webidl2.InterfaceType | webidl2.DictionaryType | webidl2.InterfaceMixinType | webidl2.NamespaceType, options?: Options) {
+function convertInterface(
+  idl: webidl2.InterfaceType | webidl2.DictionaryType | webidl2.InterfaceMixinType | webidl2.NamespaceType,
+  options?: Options,
+) {
   const members: ts.TypeElement[] = []
   const inheritance = []
   if ('inheritance' in idl && idl.inheritance) {
@@ -326,7 +329,11 @@ function convertArgument(idl: webidl2.Argument) {
 }
 function makeFinalType(type: ts.TypeNode, idl: webidl2.IDLTypeDescription): ts.TypeNode {
   if (idl.nullable) {
-    return ts.factory.createUnionTypeNode([type, ts.factory.createNull() as unknown as ts.TypeNode])
+    const types = [type, ts.factory.createTypeReferenceNode('null')]
+    if (idl.type !== 'return-type') {
+      types.push(ts.factory.createTypeReferenceNode('undefined'))
+    }
+    return ts.factory.createUnionTypeNode(types)
   }
   return type
 }

--- a/src/convert-idl.ts
+++ b/src/convert-idl.ts
@@ -27,7 +27,7 @@ const baseTypeConversionMap = new Map<string, string>([
   ...[...stringTypes].map((type) => [type, 'string'] as [string, string]),
   ...[...sameTypes].map((type) => [type, type] as [string, string]),
   ['object', 'any'],
-  ['sequence', 'Array'],
+  ['sequence', 'Iterable'],
   ['record', 'Record'],
   ['FrozenArray', 'ReadonlyArray'],
   ['EventHandler', 'EventHandler'],


### PR DESCRIPTION
- Correctly handle optional args before required args
- Translate nullable inputs as T|undefined|null
- Translate sequence as Iterable instead of Array. Works because:
  > WebGPU doesn't actually use any output `sequence`s (IIRC), instead using `FrozenArray` (which as of today it only uses in one place).

Fixes https://github.com/darionco/bikeshed-to-ts/issues/6